### PR TITLE
Requiring laravel/framework instead of laravel/laravel

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -2,7 +2,7 @@
     "name": "banityt/laravel-impersonate",
     "type": "library",
     "require": {
-        "laravel/laravel": ">=5.6",
+        "laravel/framework": ">=5.6",
         "php": "^7.1.3"
     },
     "license": "MIT",


### PR DESCRIPTION
@dexmans feel free to submit your own pull request but thought I would see if we can get this merged.